### PR TITLE
add support for description

### DIFF
--- a/src/float.js
+++ b/src/float.js
@@ -28,6 +28,7 @@ export default ({
   sanitize,
   test,
   name,
+  description,
 }) => {
   if (!name) {
     throw new Error('"name" is required');
@@ -103,6 +104,7 @@ export default ({
 
   return new GraphQLScalarType({
     name,
+    description,
     serialize: coerceFloat,
     parseValue,
     parseLiteral(ast) {

--- a/src/int.js
+++ b/src/int.js
@@ -33,6 +33,7 @@ export default ({
   sanitize,
   test,
   name,
+  description,
 }) => {
   if (!name) {
     throw new Error('"name" is required');
@@ -108,6 +109,7 @@ export default ({
 
   return new GraphQLScalarType({
     name,
+    description,
     serialize: coerceInt,
     parseValue,
     parseLiteral(ast) {


### PR DESCRIPTION
This PR adds support for passing a description string to GraphQLScalarType.
This enables a custom description per custom type created.